### PR TITLE
Handle recursive types

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,11 @@
                 {
                     "name": "RUST_BACKTRACE",
                     "value": "1"
-                }
+                },
+                {
+                    "name": "RUST_LOG",
+                    "value": "info"
+                },
             ],
             "args": [
                 "cortex-m",
@@ -28,7 +32,7 @@
             ],
             "preLaunchTask": "rust: cargo build",
             "console": "integratedTerminal",
-        }
+        },
         {
             "name": "(Windows) Launch with probe",
             "type": "cppvsdbg",
@@ -44,7 +48,11 @@
                 {
                     "name": "RUST_BACKTRACE",
                     "value": "1"
-                }
+                },
+                {
+                    "name": "RUST_LOG",
+                    "value": "info"
+                },
             ],
             "args": [
                 "probe",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -69,7 +69,16 @@ enum Platform {
     },
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() {
+    match result_main() {
+        Ok(_) => {}
+        Err(e) => {
+            println!("Error: {e}");
+        }
+    }
+}
+
+fn result_main() -> Result<(), Box<dyn Error>> {
     simple_logger::SimpleLogger::new()
         .with_level(log::LevelFilter::Off)
         .env()

--- a/trace/src/error.rs
+++ b/trace/src/error.rs
@@ -1,18 +1,20 @@
 //! All error types of the crate
 
+use std::rc::Rc;
+
 use stackdump_core::device_memory::{MemoryReadError, MissingRegisterError};
 use thiserror::Error;
 
 /// The main error type during the tracing procedure
 #[allow(missing_docs)]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum TraceError {
     #[error("The elf file does not contain the required `{0}` section")]
     MissingElfSection(String),
     #[error("The elf file could not be read: {0}")]
     ObjectReadError(#[from] addr2line::object::Error),
     #[error("An IO error occured: {0}")]
-    IOError(#[from] std::io::Error),
+    IOError(Rc<std::io::Error>),
     #[error("Some memory could not be read: {0}")]
     MemoryReadError(#[from] MemoryReadError),
     #[error("Some debug information could not be parsed: {0}")]
@@ -60,4 +62,10 @@ pub enum TraceError {
         pointer_name: String,
         class_value: gimli::DwAddr,
     },
+}
+
+impl From<std::io::Error> for TraceError {
+    fn from(e: std::io::Error) -> Self {
+        Self::IOError(Rc::new(e))
+    }
 }

--- a/trace/src/lib.rs
+++ b/trace/src/lib.rs
@@ -20,11 +20,12 @@ mod gimli_extensions;
 pub mod platform;
 mod render_colors;
 pub mod type_value_tree;
+mod variables;
 
 type DefaultReader = EndianReader<RunTimeEndian, Rc<[u8]>>;
 
 /// A source code location
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Location {
     /// The file path of the piece of code
     pub file: Option<String>,

--- a/trace/src/type_value_tree/mod.rs
+++ b/trace/src/type_value_tree/mod.rs
@@ -50,6 +50,8 @@ pub enum VariableDataError {
     },
     #[error("Pointer data is invalid")]
     InvalidPointerData,
+    #[error("nullptr")]
+    NullPointer,
     #[error("Some memory could not be read: {0}")]
     MemoryReadError(#[from] MemoryReadError),
     #[error("Data not available")]

--- a/trace/src/type_value_tree/rendering.rs
+++ b/trace/src/type_value_tree/rendering.rs
@@ -27,7 +27,7 @@ fn render_unknown<ADDR: funty::Integral>(type_value_node: &TypeValueNode<ADDR>) 
         | Archetype::Class
         | Archetype::ObjectMemberPointer => render_object(type_value_node),
         Archetype::BaseType(_) => render_base_type(type_value_node),
-        Archetype::Pointer => render_pointer(type_value_node),
+        Archetype::Pointer(_) => render_pointer(type_value_node),
         Archetype::Array => render_array(type_value_node),
         Archetype::Enumeration => render_enumeration(type_value_node),
         Archetype::Enumerator | Archetype::TaggedUnionVariant => {

--- a/trace/src/type_value_tree/variable_type.rs
+++ b/trace/src/type_value_tree/variable_type.rs
@@ -1,4 +1,4 @@
-use gimli::DwAte;
+use gimli::{DebugInfoOffset, DwAte};
 
 #[derive(Debug, Clone, Default)]
 pub struct VariableType {
@@ -15,7 +15,11 @@ pub enum Archetype {
     /// For example: the vtable of an object's Debug impl.
     ObjectMemberPointer,
     BaseType(DwAte),
-    Pointer,
+    /// A pointer that points at an object.
+    ///
+    /// The type is not directly encoded in the tree because linked lists exists.
+    /// We need to catch that to avoid recursions of linked lists.
+    Pointer(DebugInfoOffset),
     Array,
     TaggedUnion,
     TaggedUnionVariant,

--- a/trace/src/variables/type_value_tree_building/array.rs
+++ b/trace/src/variables/type_value_tree_building/array.rs
@@ -1,0 +1,95 @@
+use crate::{
+    error::TraceError,
+    gimli_extensions::{AttributeExt, DebuggingInformationEntryExt},
+    type_value_tree::{variable_type::Archetype, TypeValue, TypeValueTree},
+    variables::{build_type_value_tree, get_entry_type_reference_tree},
+    DefaultReader,
+};
+use gimli::{Abbreviations, DebugInfoOffset, Dwarf, Unit};
+use std::collections::HashMap;
+
+pub fn build_array<W: funty::Integral>(
+    dwarf: &Dwarf<DefaultReader>,
+    unit: &Unit<DefaultReader, usize>,
+    abbreviations: &Abbreviations,
+    node: gimli::EntriesTreeNode<DefaultReader>,
+    type_cache: &mut HashMap<DebugInfoOffset, Result<TypeValueTree<W>, TraceError>>,
+) -> Result<TypeValueTree<W>, TraceError> {
+    let mut type_value_tree = TypeValueTree::new(TypeValue::default());
+    let mut type_value = type_value_tree.root_mut();
+    let entry = node.entry();
+
+    let entry_tag = entry.tag().to_string();
+
+    // Arrays are their own thing in DWARF.
+    // They have no name.
+    // What can be found on the entry are the type of the elements of the array and the byte size.
+    // Arrays have one child entry that contains information about the indexing of the array.
+
+    let mut base_element_type_tree = get_entry_type_reference_tree(unit, abbreviations, entry)
+        .map(|mut type_tree| {
+        type_tree
+            .root()
+            .map(|root| build_type_value_tree(dwarf, unit, abbreviations, root, type_cache))
+    })???;
+
+    base_element_type_tree.root_mut().data_mut().name = "base".into();
+
+    let byte_size = entry
+        .attr(gimli::constants::DW_AT_byte_size)?
+        .and_then(|bsize| bsize.udata_value());
+    let element_bitsize = base_element_type_tree.data().bit_length();
+
+    let mut children = node.children();
+    let child = children
+        .next()?
+        .ok_or(TraceError::ExpectedChildNotPresent { entry_tag })?;
+    let child_entry = child.entry();
+
+    let lower_bound = child_entry
+        .required_attr(unit, gimli::constants::DW_AT_lower_bound)?
+        .sdata_value()
+        .unwrap_or(0);
+
+    // There's either a count or an upper bound
+    let count = match (
+        child_entry
+            .required_attr(unit, gimli::constants::DW_AT_count)
+            .and_then(|c| c.required_udata_value()),
+        child_entry
+            .required_attr(unit, gimli::constants::DW_AT_upper_bound)
+            .and_then(|c| c.required_sdata_value()),
+    ) {
+        // We've got a count, so let's use that
+        (Ok(count), _) => Ok(count),
+        // We've got an upper bound, so let's calculate the count from that
+        (_, Ok(upper_bound)) => Ok((upper_bound - lower_bound).try_into().unwrap()),
+        // Both are not readable
+        (Err(e), Err(_)) => Err(e),
+    }?;
+
+    type_value.data_mut().bit_range.end = type_value.data_mut().bit_range.start
+        + byte_size
+            .map(|byte_size| byte_size * 8)
+            .unwrap_or_else(|| element_bitsize * count);
+    type_value.data_mut().variable_type.name = format!(
+        "[{};{}]",
+        base_element_type_tree.data().variable_type.name,
+        count
+    );
+    type_value.data_mut().variable_type.archetype = Archetype::Array;
+
+    for data_index in lower_bound..(lower_bound + count as i64) {
+        let mut element_type_tree = base_element_type_tree.clone();
+
+        element_type_tree.root_mut().data_mut().name = data_index.to_string();
+        element_type_tree.root_mut().data_mut().bit_range.start +=
+            data_index as u64 * element_bitsize;
+        element_type_tree.root_mut().data_mut().bit_range.end +=
+            data_index as u64 * element_bitsize;
+
+        type_value.push_back(element_type_tree);
+    }
+
+    Ok(type_value_tree)
+}

--- a/trace/src/variables/type_value_tree_building/base_type.rs
+++ b/trace/src/variables/type_value_tree_building/base_type.rs
@@ -1,0 +1,47 @@
+use crate::{
+    error::TraceError,
+    gimli_extensions::{AttributeExt, DebuggingInformationEntryExt},
+    type_value_tree::{variable_type::Archetype, TypeValue, TypeValueTree},
+    variables::get_entry_name,
+    DefaultReader,
+};
+use gimli::{AttributeValue, Dwarf, Unit};
+
+pub fn build_base_type<W: funty::Integral>(
+    dwarf: &Dwarf<DefaultReader>,
+    unit: &Unit<DefaultReader, usize>,
+    node: gimli::EntriesTreeNode<DefaultReader>,
+) -> Result<TypeValueTree<W>, TraceError> {
+    let mut type_value_tree = TypeValueTree::new(TypeValue::default());
+    let mut type_value = type_value_tree.root_mut();
+    let entry = node.entry();
+
+    // A base type is a primitive and there are many of them.
+    // Which base type this is, is recorded in the `DW_AT_encoding` attribute.
+    // The value of that attribute is a `DwAte`.
+
+    // We record the name, the encoding and the size of the primitive
+
+    let name = get_entry_name(dwarf, unit, entry)?;
+    let encoding = entry
+        .required_attr(unit, gimli::constants::DW_AT_encoding)
+        .map(|attr| {
+            if let AttributeValue::Encoding(encoding) = attr.value() {
+                Ok(encoding)
+            } else {
+                Err(TraceError::WrongAttributeValueType {
+                    attribute_name: attr.name().to_string(),
+                    value_type_name: "Encoding",
+                })
+            }
+        })??;
+    let byte_size = entry
+        .required_attr(unit, gimli::constants::DW_AT_byte_size)?
+        .required_udata_value()?;
+
+    type_value.data_mut().variable_type.name = name;
+    type_value.data_mut().variable_type.archetype = Archetype::BaseType(encoding);
+    type_value.data_mut().bit_range = 0..byte_size * 8;
+
+    Ok(type_value_tree)
+}

--- a/trace/src/variables/type_value_tree_building/enumeration.rs
+++ b/trace/src/variables/type_value_tree_building/enumeration.rs
@@ -1,0 +1,76 @@
+use crate::{
+    error::TraceError,
+    gimli_extensions::{AttributeExt, DebuggingInformationEntryExt},
+    type_value_tree::{
+        value::Value,
+        variable_type::{Archetype, VariableType},
+        TypeValue, TypeValueTree,
+    },
+    variables::{build_type_value_tree, get_entry_name, get_entry_type_reference_tree},
+    DefaultReader,
+};
+use gimli::{Abbreviations, DebugInfoOffset, Dwarf, Unit};
+use std::collections::HashMap;
+
+pub fn build_enumeration<W: funty::Integral>(
+    dwarf: &Dwarf<DefaultReader>,
+    unit: &Unit<DefaultReader, usize>,
+    abbreviations: &Abbreviations,
+    node: gimli::EntriesTreeNode<DefaultReader>,
+    type_cache: &mut HashMap<DebugInfoOffset, Result<TypeValueTree<W>, TraceError>>,
+) -> Result<TypeValueTree<W>, TraceError> {
+    let mut type_value_tree = TypeValueTree::new(TypeValue::default());
+    let mut type_value = type_value_tree.root_mut();
+    let entry = node.entry();
+
+    // This is an enum type (like a C-style enum).
+    // Enums have a name and also an underlying_type (which is usually an integer).
+    // The entry also has a child `DW_TAG_enumerator` for each variant.
+
+    let name = get_entry_name(dwarf, unit, entry)?;
+    let mut underlying_type_tree = get_entry_type_reference_tree(unit, abbreviations, entry)
+        .map(|mut type_tree| {
+        type_tree
+            .root()
+            .map(|root| build_type_value_tree(dwarf, unit, abbreviations, root, type_cache))
+    })???;
+    underlying_type_tree.root_mut().data_mut().name = "base".into();
+    let underlying_type_bitrange = underlying_type_tree.root().data().bit_range.clone();
+
+    type_value.data_mut().variable_type.name = name;
+    type_value.data_mut().variable_type.archetype = Archetype::Enumeration;
+    type_value.data_mut().bit_range = underlying_type_bitrange.clone();
+
+    type_value.push_back(underlying_type_tree);
+
+    let mut children = node.children();
+    while let Ok(Some(child)) = children.next() {
+        let enumerator_entry = child.entry();
+
+        // Each child is a DW_TAG_enumerator or DW_TAG_subprogram
+        if enumerator_entry.tag() != gimli::constants::DW_TAG_enumerator {
+            continue;
+        }
+
+        // Each variant has a name and an integer value.
+        // If the enum has that value, then the enum is of that variant.
+        // This does of course not work for flag enums.
+
+        let enumerator_name = get_entry_name(dwarf, unit, enumerator_entry)?;
+        let const_value = enumerator_entry
+            .required_attr(unit, gimli::constants::DW_AT_const_value)?
+            .required_sdata_value()?;
+
+        type_value.push_back(TypeValueTree::new(TypeValue {
+            name: enumerator_name,
+            variable_type: VariableType {
+                name: "".into(),
+                archetype: Archetype::Enumerator,
+            },
+            bit_range: underlying_type_bitrange.clone(),
+            variable_value: Ok(Value::Int(const_value as i128)),
+        }));
+    }
+
+    Ok(type_value_tree)
+}

--- a/trace/src/variables/type_value_tree_building/mod.rs
+++ b/trace/src/variables/type_value_tree_building/mod.rs
@@ -1,0 +1,17 @@
+mod tagged_union;
+pub use tagged_union::build_tagged_union;
+
+mod object;
+pub use object::build_object;
+
+mod base_type;
+pub use base_type::build_base_type;
+
+mod pointer;
+pub use pointer::build_pointer;
+
+mod array;
+pub use array::build_array;
+
+mod enumeration;
+pub use enumeration::build_enumeration;

--- a/trace/src/variables/type_value_tree_building/object.rs
+++ b/trace/src/variables/type_value_tree_building/object.rs
@@ -1,0 +1,131 @@
+use crate::{
+    error::TraceError,
+    gimli_extensions::{AttributeExt, DebuggingInformationEntryExt},
+    type_value_tree::{variable_type::Archetype, TypeValue, TypeValueTree},
+    variables::{
+        build_type_value_tree, get_entry_name, get_entry_type_reference_tree,
+        read_data_member_location,
+    },
+    DefaultReader,
+};
+use gimli::{Abbreviations, DebugInfoOffset, DwTag, Dwarf, Unit};
+use std::collections::HashMap;
+
+pub fn build_object<W: funty::Integral>(
+    dwarf: &Dwarf<DefaultReader>,
+    unit: &Unit<DefaultReader, usize>,
+    abbreviations: &Abbreviations,
+    node: gimli::EntriesTreeNode<DefaultReader>,
+    type_cache: &mut HashMap<DebugInfoOffset, Result<TypeValueTree<W>, TraceError>>,
+    tag: DwTag,
+) -> Result<TypeValueTree<W>, TraceError> {
+    let mut type_value_tree = TypeValueTree::new(TypeValue::default());
+    let mut type_value = type_value_tree.root_mut();
+    let entry = node.entry();
+
+    // We have an object with members
+    // The informations we can gather is:
+    // - type name
+    // - type parameters
+    // - the members of the object
+    // - the byte size of the object
+
+    let type_name = get_entry_name(dwarf, unit, entry)?;
+    let byte_size = entry
+        .required_attr(unit, gimli::constants::DW_AT_byte_size)?
+        .required_udata_value()?;
+
+    // Check if this is a type that wraps another type
+    let is_member_pointer = entry
+        .attr(gimli::constants::DW_AT_containing_type)?
+        .is_some();
+
+    let archetype = match (tag, is_member_pointer) {
+        (_, true) => Archetype::ObjectMemberPointer,
+        (gimli::constants::DW_TAG_structure_type, _) => Archetype::Structure,
+        (gimli::constants::DW_TAG_union_type, _) => Archetype::Union,
+        (gimli::constants::DW_TAG_class_type, _) => Archetype::Class,
+        _ => unreachable!(),
+    };
+
+    type_value.data_mut().variable_type.name = type_name.clone();
+    type_value.data_mut().variable_type.archetype = archetype;
+    type_value.data_mut().bit_range = 0..byte_size * 8;
+
+    // The members of the object can be found by looking at the children of the node
+    let mut children = node.children();
+    while let Ok(Some(child)) = children.next() {
+        let member_entry = child.entry();
+
+        // We can be a normal object, but we can also still be a tagged union.
+        // We know that we're a tagged union if one of the members has the `DW_TAG_variant_part` tag, so we'll check for that.
+        // If this object is a tagged union, then we will assume it isn't also a a normal object even though
+        // that could be the case with how the DWARF spec states things. This isn't something Rust and I think even C++ can do.
+
+        if member_entry.tag() == gimli::constants::DW_TAG_variant_part {
+            // This is a tagged union, so ignore everything and build the type value tree from this child
+            let mut tagged_union =
+                build_type_value_tree(dwarf, unit, abbreviations, child, type_cache);
+
+            if let Ok(tagged_union) = tagged_union.as_mut() {
+                // The tagged union child doesn't have a name or byte size, so we need to give it the name of the object we
+                // we thought we would get
+                tagged_union.root_mut().data_mut().variable_type.name = type_name;
+                tagged_union.root_mut().data_mut().bit_range = 0..byte_size * 8;
+            }
+
+            return tagged_union;
+        }
+
+        // This is an object and not a tagged union
+
+        // Object children can be a couple of things:
+        // - Member fields
+        // - Sub programs (methods)
+        // - Other objects (TODO what does this mean?)
+
+        // Member fields have a name, a type and a location offset (relative to the base of the object).
+        // Type parameters only have a name and a type.
+        // The rest of the children are ignored.
+
+        let member_name = match get_entry_name(dwarf, unit, member_entry) {
+            Ok(member_name) => member_name,
+            Err(_) => continue, // Only care about named members for now
+        };
+
+        match member_entry.tag() {
+            gimli::constants::DW_TAG_member => {
+                let member_location_offset_bits = read_data_member_location(unit, member_entry)?;
+
+                let mut member_tree =
+                    get_entry_type_reference_tree(unit, abbreviations, member_entry).map(
+                        |mut type_tree| {
+                            type_tree.root().map(|root| {
+                                build_type_value_tree(dwarf, unit, abbreviations, root, type_cache)
+                            })
+                        },
+                    )???;
+
+                member_tree.root_mut().data_mut().name = member_name;
+                member_tree.root_mut().data_mut().bit_range.end += member_location_offset_bits;
+                member_tree.root_mut().data_mut().bit_range.start += member_location_offset_bits;
+
+                type_value.push_back(member_tree);
+            }
+            gimli::constants::DW_TAG_template_type_parameter => {} // Ignore
+            gimli::constants::DW_TAG_subprogram => {}              // Ignore
+            gimli::constants::DW_TAG_structure_type
+            | gimli::constants::DW_TAG_union_type
+            | gimli::constants::DW_TAG_class_type => {} // Ignore
+            member_tag => {
+                return Err(TraceError::UnexpectedMemberTag {
+                    object_name: type_name,
+                    member_name,
+                    member_tag,
+                })
+            }
+        }
+    }
+
+    Ok(type_value_tree)
+}

--- a/trace/src/variables/type_value_tree_building/pointer.rs
+++ b/trace/src/variables/type_value_tree_building/pointer.rs
@@ -1,0 +1,82 @@
+use crate::{
+    error::TraceError,
+    gimli_extensions::{AttributeExt, DebuggingInformationEntryExt},
+    type_value_tree::{variable_type::Archetype, TypeValue, TypeValueTree},
+    variables::{build_type_value_tree, get_entry_name, get_entry_type_reference_tree},
+    DefaultReader,
+};
+use gimli::{Abbreviations, DebugInfoOffset, Dwarf, Unit};
+use std::collections::HashMap;
+
+pub fn build_pointer<W: funty::Integral>(
+    dwarf: &Dwarf<DefaultReader>,
+    unit: &Unit<DefaultReader, usize>,
+    abbreviations: &Abbreviations,
+    node: gimli::EntriesTreeNode<DefaultReader>,
+    type_cache: &mut HashMap<DebugInfoOffset, Result<TypeValueTree<W>, TraceError>>,
+) -> Result<TypeValueTree<W>, TraceError> {
+    let mut type_value_tree = TypeValueTree::new(TypeValue::default());
+    let mut type_value = type_value_tree.root_mut();
+    let entry = node.entry();
+
+    let entry_die_offset = entry.offset().to_debug_info_offset(&unit.header).unwrap();
+
+    // A pointer in this context is just a number.
+    // It has a name and a type that indicates the type of the object it points to.
+
+    let (pointee_type_name, pointee_type_die_offset) =
+        get_entry_type_reference_tree(unit, abbreviations, entry).map(|mut type_tree| {
+            type_tree.root().map(|root| {
+                let die_offset = root
+                    .entry()
+                    .offset()
+                    .to_debug_info_offset(&unit.header)
+                    .unwrap();
+
+                let pointee_type_name = get_entry_name(dwarf, unit, root.entry());
+
+                pointee_type_name.map(|ptn| (ptn, die_offset))
+            })
+        })???;
+
+    // Some pointers don't have names, but generally it is just `&<typename>`
+    // So if only the name is missing, we can recover
+
+    let name =
+        get_entry_name(dwarf, unit, entry).unwrap_or_else(|_| format!("&{pointee_type_name}"));
+
+    // The debug info also contains an address class that can describe what kind of pointer it is.
+    // We only support `DW_ADDR_none` for now, which means that there's no special specification.
+    // We do perform the check though to be sure.
+
+    let address_class = entry
+        .required_attr(unit, gimli::constants::DW_AT_address_class)?
+        .required_address_class()?;
+    if address_class != gimli::constants::DW_ADDR_none {
+        return Err(TraceError::UnexpectedPointerClass {
+            pointer_name: name,
+            class_value: address_class,
+        });
+    }
+
+    type_value.data_mut().variable_type.name = name;
+    type_value.data_mut().variable_type.archetype = Archetype::Pointer(pointee_type_die_offset);
+    type_value.data_mut().bit_range = 0..W::BITS as u64;
+
+    // Insert this pointer into the type cache
+    type_cache.insert(entry_die_offset, Ok(type_value_tree.clone()));
+
+    // Insert the pointee into the type cache
+    if !type_cache.contains_key(&pointee_type_die_offset) {
+        let pointee_type_tree = get_entry_type_reference_tree(unit, abbreviations, entry).map(
+            |mut type_tree| {
+                type_tree
+                    .root()
+                    .map(|root| build_type_value_tree(dwarf, unit, abbreviations, root, type_cache))
+            },
+        )???;
+        type_cache.insert(pointee_type_die_offset, Ok(pointee_type_tree));
+    }
+
+    Ok(type_value_tree)
+}

--- a/trace/src/variables/type_value_tree_building/tagged_union.rs
+++ b/trace/src/variables/type_value_tree_building/tagged_union.rs
@@ -1,0 +1,146 @@
+use crate::{
+    error::TraceError,
+    gimli_extensions::{AttributeExt, DebuggingInformationEntryExt},
+    type_value_tree::{
+        value::Value,
+        variable_type::{Archetype, VariableType},
+        TypeValue, TypeValueTree, VariableDataError,
+    },
+    variables::{build_type_value_tree, get_entry_type_reference_tree, read_data_member_location},
+    DefaultReader,
+};
+use gimli::{Abbreviations, AttributeValue, DebugInfoOffset, Dwarf, Unit};
+use std::collections::HashMap;
+
+pub fn build_tagged_union<W: funty::Integral>(
+    dwarf: &Dwarf<DefaultReader>,
+    unit: &Unit<DefaultReader, usize>,
+    abbreviations: &Abbreviations,
+    node: gimli::EntriesTreeNode<DefaultReader>,
+    type_cache: &mut HashMap<DebugInfoOffset, Result<TypeValueTree<W>, TraceError>>,
+) -> Result<TypeValueTree<W>, TraceError> {
+    let mut type_value_tree = TypeValueTree::new(TypeValue::default());
+    let mut type_value = type_value_tree.root_mut();
+    let entry = node.entry();
+
+    // We can't read the name and byte size, but we'll get that assigned when we return, so don't do that here
+    // Read the DW_AT_discr. It will have a reference to the DIE that we can read to know which variant is active.
+    // This will probably be an integer.
+    type_value.data_mut().variable_type.archetype = Archetype::TaggedUnion;
+    type_value.data_mut().variable_value = Ok(Value::Object);
+
+    let discriminant_attr = entry.required_attr(unit, gimli::constants::DW_AT_discr)?;
+
+    let discriminant_unit_offset =
+        if let AttributeValue::UnitRef(offset) = discriminant_attr.value() {
+            Ok(offset)
+        } else {
+            Err(TraceError::WrongAttributeValueType {
+                attribute_name: discriminant_attr.name().to_string(),
+                value_type_name: "UnitRef",
+            })
+        }?;
+
+    let discriminant_entry = unit.entry(discriminant_unit_offset)?;
+
+    // We've got some data about the discriminant, let's make it our first type value child
+
+    let mut discriminant_tree =
+        get_entry_type_reference_tree(unit, abbreviations, &discriminant_entry).map(
+            |mut type_tree| {
+                type_tree
+                    .root()
+                    .map(|root| build_type_value_tree(dwarf, unit, abbreviations, root, type_cache))
+            },
+        )???;
+    discriminant_tree.root_mut().data_mut().name = "discriminant".into();
+
+    // The discriminant has its own member location, so we need to offset the bit range
+    let discriminant_location_offset_bits = read_data_member_location(unit, &discriminant_entry)?;
+    discriminant_tree.root_mut().data_mut().bit_range.start += discriminant_location_offset_bits;
+    discriminant_tree.root_mut().data_mut().bit_range.end += discriminant_location_offset_bits;
+
+    type_value_tree.push_back(discriminant_tree);
+
+    // Now we need to read all of the variant parts which are the children of the entry.
+
+    let mut children = node.children();
+    while let Ok(Some(child)) = children.next() {
+        let variant_entry = child.entry();
+
+        // We'll find more nodes there as well like types and members. We can ignore those because if they are
+        // relevant, we'll find them indirectly. For example, the member we'll likely find is the discriminant and
+        // the types we'll find are the types that are defined for each variant.
+
+        if variant_entry.tag() != gimli::constants::DW_TAG_variant {
+            continue;
+        }
+
+        // We've found a variant part!
+        // Three things can happen:
+        // 1. It has a DW_AT_discr_value
+        // 2. It has a DW_AT_discr_list
+        // 3. It has nothing
+        //
+        // The first gives the value the discriminant has to have for this variant to be active.
+        // The second one has a list of values, but I haven't seen that that being generated so far. We'll check
+        // and give an error in that case.
+        // A variant with nothing is the default case. If no other variant matches, then this one is selected.
+
+        let discr_value = variant_entry.attr(gimli::constants::DW_AT_discr_value)?;
+        let discr_list = variant_entry.attr(gimli::constants::DW_AT_discr_list)?;
+
+        let discriminator_value = match (discr_value, discr_list) {
+            (Some(discr_value), _) => Some(discr_value.required_sdata_value()?),
+            (_, Some(_)) => {
+                return Err(TraceError::OperationNotImplemented {
+                    operation: "Reading the discr_list".into(),
+                })
+            }
+            (None, None) => None,
+        };
+
+        // We know the value, so we can create a type value tree for the variant part
+
+        let mut variant_tree = TypeValueTree::new(TypeValue {
+            name: "variant".into(),
+            variable_type: VariableType {
+                name: "".into(),
+                archetype: Archetype::TaggedUnionVariant,
+            },
+            bit_range: 0..0,
+            variable_value: discriminator_value
+                .map(|v| Value::Int(v as _))
+                .ok_or(VariableDataError::NoDataAvailable),
+        });
+
+        // Variant parts have one child that is their actual value
+
+        let mut variant_children = child.children();
+        let variant_member =
+            variant_children
+                .next()?
+                .ok_or(TraceError::ExpectedChildNotPresent {
+                    entry_tag: "DW_TAG_variant_part".into(),
+                })?;
+
+        let variant_member_bit_offset = read_data_member_location(unit, variant_member.entry())?;
+
+        let variant_member_tree =
+            get_entry_type_reference_tree(unit, abbreviations, variant_member.entry()).map(
+                |mut type_tree| {
+                    type_tree.root().map(|root| {
+                        build_type_value_tree(dwarf, unit, abbreviations, root, type_cache)
+                    })
+                },
+            )???;
+
+        variant_tree.root_mut().data_mut().bit_range = variant_member_bit_offset
+            ..variant_member_bit_offset + variant_member_tree.root().data().bit_length();
+
+        variant_tree.push_back(variant_member_tree);
+        type_value_tree.push_back(variant_tree);
+    }
+
+    Ok(type_value_tree)
+}


### PR DESCRIPTION
Fixes #6 

All variable type trees are now cached (before values are read)
Pointers no longer directly read their pointee types, but read them from cache
Big code refactor for Variables